### PR TITLE
Protect SSH Secrets from Sync Deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ chmod +x *.sh && ./setup.sh
 - 🔁 **Retry Logic**: Automatically retries failed uploads
 - 🎯 **Environment Support**: Repository and environment-specific secrets
 - ⏭️ **Skip Existing Secrets**: Option to skip secrets that already exist
-- 🔄 **Sync Mode**: Delete GitHub secrets that are not present in .env file
+- 🔄 **Sync Mode**: Delete GitHub secrets that are not present in .env file (SSH secrets are always preserved)
 - 📊 **Progress Tracking**: Detailed progress and summary reporting
 - 🔧 **Cross-Platform**: macOS, Linux, and Windows support
 

--- a/gh-secrets-upload.sh
+++ b/gh-secrets-upload.sh
@@ -399,6 +399,12 @@ process_env_file() {
         # Delete secrets that exist in GitHub but not in .env
         while IFS= read -r github_secret; do
             [ -z "$github_secret" ] && continue
+
+            # Protect SSH-related secrets from deletion during sync
+            if [[ "${github_secret^^}" == *"SSH"* ]]; then
+                log_warn "Skipping $github_secret (contains 'SSH'; protected from sync deletion)"
+                continue
+            fi
             
             # Check if this GitHub secret exists in our local .env file
             local found=false


### PR DESCRIPTION
## Overview
Running the uploader with `--sync` removes any remote secret missing from the .env file. Teams store immutable deployment keys (e.g., `PROD_SSH_KEY`, `SSH_CONFIG`) directly in GitHub and do not duplicate them in the env file, so every sync run re-created the secret churn or, worse, deleted the deploy key. This PR makes sync mode aware of SSH secrets and skips removing them, eliminating that sharp edge.

## Details
- treat any secret whose name includes `SSH` (case-insensitive) as protected during sync; log a warning when it is skipped so the operator knows why it was left untouched
- leave upload behavior unchanged: secrets explicitly present in the .env file can still be set/updated, ensuring backwards compatibility for teams that intentionally rotate SSH values through the script
- note the new safety in the README features list so adopters know sync will not nuke SSH keys